### PR TITLE
Bhamelin/fix text clear

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -261,20 +261,22 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		}
 	}
 
-	_addAttribute(newValue) {
+	async _addAttribute(newValue) {
 		if (!newValue || this.attributeList.findIndex(attribute => attribute.value === newValue) >= 0) {
 			return;
 		}
 		this.attributeList = [...this.attributeList, newValue];
 		this._text = '';
 
-		//Ensure the dropdown index doesn't go out of bounds after adding this attribute
+		//Wait until we can get the full list of available list items after clearing the text
+		await this.updateComplete;
+
 		const list = this.shadowRoot.querySelectorAll('li');
-		if (this._dropdownIndex > -1 && (list.length === 1 || list.length - 1 === this._dropdownIndex)) {
+
+		//If we removed the final index of the list, move our index back to compensate
+		if (this._dropdownIndex > -1 && this._dropdownIndex > list.length - 1) {
 			this._dropdownIndex --;
 		}
-
-		this.requestUpdate();
 
 		this.dispatchEvent(new CustomEvent('attributes-changed', {
 			bubbles: true,
@@ -425,9 +427,8 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 	_onInputTextChanged(event) {
 		this._text = event.target.value;
 		if (this._dropdownIndex >= 0) {
-			this._dropdownIndex = 0;
+			this.allowFreeform ? this._dropdownIndex = -1 : this._dropdownIndex = 0;
 		}
-
 		this.requestUpdate();
 	}
 

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -269,7 +269,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		this._text = '';
 
 		//Ensure the dropdown index doesn't go out of bounds after adding this attribute
-		const list = this.shadowRoot.querySelectorAll('li')
+		const list = this.shadowRoot.querySelectorAll('li');
 		if (this._dropdownIndex > -1 && (list.length === 1 || list.length - 1 === this._dropdownIndex)) {
 			this._dropdownIndex --;
 		}

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -266,6 +266,14 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			return;
 		}
 		this.attributeList = [...this.attributeList, newValue];
+		this._text = '';
+
+		//Ensure the dropdown index doesn't go out of bounds after adding this attribute
+		const list = this.shadowRoot.querySelectorAll('li')
+		if (this._dropdownIndex > -1 && (list.length === 1 || list.length - 1 === this._dropdownIndex)) {
+			this._dropdownIndex --;
+		}
+
 		this.requestUpdate();
 
 		this.dispatchEvent(new CustomEvent('attributes-changed', {
@@ -283,11 +291,6 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 	_attributeLimitReached() {
 		return this.limit && (this.attributeList.length >= this.limit);
-	}
-
-	_menuItemFocused(e) {
-		this._addAttribute(e.target.text);
-		this._menuItemFocused = true;
 	}
 
 	// Absolute value % operator for navigating menus.
@@ -407,15 +410,10 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 				if (this._dropdownIndex >= 0 && this._dropdownIndex < list.length) {
 					this._addAttribute(list[this._dropdownIndex].text);
-					this._text = '';
-					if (list.length === 1 || list.length - 1 === this._dropdownIndex) {
-						this._dropdownIndex --;
-					}
 				} else if (this.allowFreeform) {
 					const trimmedAttribute =  this._text.trim();
 					if (trimmedAttribute.length > 0 && !this.attributeList.includes(trimmedAttribute)) {
 						this._addAttribute(this._text.trim());
-						this._text = '';
 					}
 				}
 				this._updateDropdownFocus();

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -424,6 +424,10 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 	_onInputTextChanged(event) {
 		this._text = event.target.value;
+		if (this._dropdownIndex >= 0) {
+			this._dropdownIndex = 0;
+		}
+
 		this.requestUpdate();
 	}
 


### PR DESCRIPTION
Hani found an issue where if the user typed into the input and clicked a dropdown item, the input text would not be cleared when the tag is added.

This PR should ensure the text is always cleared when a new tag is added, as well as some dropdown indexing cleanup I found as a result of investigating this.