### PR TITLE
fix: css for dropdown width determination

### DIFF
--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -151,8 +151,8 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 			.d2l-attribute-picker-absolute-container {
 				margin: 0 0.3rem 0 -0.3rem;
-				width: 100%;
 				position: absolute;
+				width: 100%;
 				z-index: 1;
 			}
 		`];

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -72,6 +72,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				box-shadow: inset 0 2px 0 0 rgba(185, 194, 208, 0.2);
 				padding: 5px 5px 5px 5px;
 				vertical-align: middle;
+				position: relative;
 			}
 			.d2l-attribute-picker-container-focused {
 				border-color: var(--d2l-color-celestine);
@@ -150,7 +151,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 
 			.d2l-attribute-picker-absolute-container {
 				margin: 0 0.3rem 0 -0.3rem;
-				min-width: 96.5%;
+				width: 100%;
 				position: absolute;
 				z-index: 1;
 			}

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -71,8 +71,8 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 				border-width: 1px;
 				box-shadow: inset 0 2px 0 0 rgba(185, 194, 208, 0.2);
 				padding: 5px 5px 5px 5px;
-				vertical-align: middle;
 				position: relative;
+				vertical-align: middle;
 			}
 			.d2l-attribute-picker-container-focused {
 				border-color: var(--d2l-color-celestine);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@brightspace-ui-labs/attribute-picker",
+  "version": "1.0.4",
   "description": "Autocompleting dropdown to choose one or more new or pre-existing attributes",
   "repository": "https://github.com/BrightspaceUILabs/attribute-picker.git",
   "scripts": {
@@ -46,6 +47,5 @@
     "@brightspace-ui/core": "^1.118.1",
     "lit-element": "^2",
     "stylelint": "^13.11.0"
-  },
-  "version": "1.0.4"
+  }
 }


### PR DESCRIPTION
Small PR that fixes some layout issues.

Due to the dropdown needing to be absolute, the sizing is based on the nearest `position:relative` parent. This should be the container, or the dropdown could expand horiztontally much more than intended (This happens in the rule picker integration)

This PR adds the missing `position:relative` onto the container, so the dropdown will size it to match the width of the input.