### PR TITLE
d2l-ify events, make addAttribute public, fix tag limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ To make your usage of `d2l-labs-attribute-picker` accessible, use the following 
 | aria-label | The label should provide context for the attribute picker, such as type of attribute. |
 
 **Events:**
-The `d2l-labs-attribute-picker` dispatches the `attributes-changed` event each time an attribute has been added or removed. It will return the updated list of attributes:
+The `d2l-labs-attribute-picker` dispatches the `d2l-attributes-changed` event each time an attribute has been added or removed. It will return the updated list of attributes:
 ```javascript
-attributePicker.addEventListener('attributes-changed', (e) => {
+attributePicker.addEventListener('d2l-attributes-changed', (e) => {
   console.log(e.detail.attributeList.toString());
 });
 ```
 
-The `d2l-labs-attribute-picker` dispatches the `attribute-limit-reached` event when the user attempts to enter an attribute greater than the limit. This can be used to send feedback to the user.
+The `d2l-labs-attribute-picker` dispatches the `d2l-attribute-limit-reached` event when the user attempts to enter an attribute greater than the limit. This can be used to send feedback to the user.
 
 ## Developing, Testing and Contributing
 

--- a/attribute-picker.js
+++ b/attribute-picker.js
@@ -279,7 +279,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			this._dropdownIndex --;
 		}
 
-		this.dispatchEvent(new CustomEvent('attributes-changed', {
+		this.dispatchEvent(new CustomEvent('d2l-attributes-changed', {
 			bubbles: true,
 			composed: true,
 			detail: {
@@ -401,7 +401,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 			case keyCodes.ENTER: {
 				const list = this.shadowRoot.querySelectorAll('li');
 				if (this._attributeLimitReached()) {
-					this.dispatchEvent(new CustomEvent('attribute-limit-reached', {
+					this.dispatchEvent(new CustomEvent('d2l-attribute-limit-reached', {
 						bubbles: true,
 						composed: true,
 						detail: {
@@ -446,7 +446,7 @@ class AttributePicker extends RtlMixin(Localizer(LitElement)) {
 		this.attributeList = this.attributeList.slice(0, index).concat(this.attributeList.slice(index + 1, this.attributeList.length));
 		this._activeAttributeIndex = -1;
 
-		this.dispatchEvent(new CustomEvent('attributes-changed', {
+		this.dispatchEvent(new CustomEvent('d2l-attributes-changed', {
 			bubbles: true,
 			composed: true,
 			detail: {

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -315,8 +315,8 @@ describe('d2l-labs-attribute-picker', () => {
 			);
 		});
 
-		it('should fire the attributes-changed event when adding a tag', async() => {
-			const listener = oneEvent(el, 'attributes-changed');
+		it('should fire the d2l-attributes-changed event when adding a tag', async() => {
+			const listener = oneEvent(el, 'd2l-attributes-changed');
 
 			const pageNumberInput = el.shadowRoot.querySelector('input');
 			pageNumberInput.focus();
@@ -328,8 +328,8 @@ describe('d2l-labs-attribute-picker', () => {
 			expect(result.detail.attributeList.length).to.equal(4);
 		});
 
-		it('should fire the attributes-changed event when removing a tag', async() => {
-			const listener = oneEvent(el, 'attributes-changed');
+		it('should fire the d2l-attributes-changed event when removing a tag', async() => {
+			const listener = oneEvent(el, 'd2l-attributes-changed');
 
 			const pageNumberInput = el.shadowRoot.querySelector('input');
 			pageNumberInput.focus();
@@ -340,8 +340,8 @@ describe('d2l-labs-attribute-picker', () => {
 			expect(result).to.not.equal('no event fired');
 		});
 
-		it('should fire the attribute-limit-reached event when attempting to add a tag beyond the limit', async() => {
-			const listener = oneEvent(el, 'attribute-limit-reached');
+		it('should fire the d2l-attribute-limit-reached event when attempting to add a tag beyond the limit', async() => {
+			const listener = oneEvent(el, 'd2l-attribute-limit-reached');
 
 			const element = el; //require-atomic-updates deems this necessary
 			const pageNumberInput = el.shadowRoot.querySelector('input');

--- a/test/attribute-picker.test.js
+++ b/test/attribute-picker.test.js
@@ -356,7 +356,7 @@ describe('d2l-labs-attribute-picker', () => {
 			pageNumberInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', keyCode: 13 }));
 			await element.requestUpdate;
 			expect(element.attributeList.length).to.equal(5);
-			element.shadowRoot.querySelector('input').text = 'six';
+			element._text = 'six';
 			pageNumberInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', keyCode: 13 }));
 			expect(element.attributeList.length).to.equal(5);
 			await element.requestUpdate;


### PR DESCRIPTION
Another small PR based on first use case testing to try to clean up remaining issues.

- Updates the API for addAttribute() to remove the underscore, as it has enough value to be worth changing to public
- Prefaces the events with `d2l-` because they should have that.
- Fixes issue where the user can dodge the attribute limit by clicking the dialog instead of pressing enter. The limit applies in addAttributes() now, for whenever new attributes are added. I was careful to test this and there is an automated test to confirm as well.